### PR TITLE
hide generated js files in vs code

### DIFF
--- a/.settings/settings.json
+++ b/.settings/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "**/.git": true,
+        "**/.DS_Store": true,
+        "**/*.js": {"when": "$(basename).ts"},
+        ".settings/": true
+    }
+}


### PR DESCRIPTION
All generated js files will be hidden
from the side bar of vs code editor.

Signed-off-by: Kanagaraj M <kmayilsa@redhat.com>